### PR TITLE
This changeset addresses the issue with processor architecture defini…

### DIFF
--- a/Ghpr.Console/Ghpr.Console.csproj
+++ b/Ghpr.Console/Ghpr.Console.csproj
@@ -37,6 +37,26 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Ghpr.Core, Version=0.9.4.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\Ghpr.Core.0.9.4\lib\net452\Ghpr.Core.dll</HintPath>
@@ -50,8 +70,8 @@
     <Reference Include="Ghpr.MSTestV2, Version=0.9.4.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\Ghpr.MSTestV2.0.9.4\lib\net452\Ghpr.MSTestV2.dll</HintPath>
     </Reference>
-    <Reference Include="Ghpr.NUnit, Version=0.9.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Ghpr.NUnit.0.9.4\lib\net452\Ghpr.NUnit.dll</HintPath>
+    <Reference Include="Ghpr.NUnit, Version=0.9.4.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Ghpr.NUnit.0.9.4.1\lib\net452\Ghpr.NUnit.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>packages\MSTest.TestFramework.1.4.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
@@ -110,7 +130,9 @@
     <None Include="Ghpr.NUnit.Settings.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/Ghpr.Console/Ghpr.Console.sln
+++ b/Ghpr.Console/Ghpr.Console.sln
@@ -1,22 +1,31 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.329
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ghpr.Console", "Ghpr.Console.csproj", "{26B5289B-FDF6-4928-989A-F5DAFA84A395}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{26B5289B-FDF6-4928-989A-F5DAFA84A395}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{26B5289B-FDF6-4928-989A-F5DAFA84A395}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{26B5289B-FDF6-4928-989A-F5DAFA84A395}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{26B5289B-FDF6-4928-989A-F5DAFA84A395}.Release|Any CPU.Build.0 = Release|Any CPU
+		{26B5289B-FDF6-4928-989A-F5DAFA84A395}.Debug|x86.ActiveCfg = Debug|x86
+		{26B5289B-FDF6-4928-989A-F5DAFA84A395}.Debug|x86.Build.0 = Debug|x86
+		{26B5289B-FDF6-4928-989A-F5DAFA84A395}.Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{26B5289B-FDF6-4928-989A-F5DAFA84A395}.Release|Any CPU.Build.0 = Debug|Any CPU
+		{26B5289B-FDF6-4928-989A-F5DAFA84A395}.Release|x86.ActiveCfg = Debug|x86
+		{26B5289B-FDF6-4928-989A-F5DAFA84A395}.Release|x86.Build.0 = Debug|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {41013FBB-DB5A-46C1-93D9-4F27DAEFD355}
 	EndGlobalSection
 EndGlobal

--- a/Ghpr.Console/packages.config
+++ b/Ghpr.Console/packages.config
@@ -4,7 +4,7 @@
   <package id="Ghpr.LocalFileSystem" version="0.9.4" targetFramework="net452" />
   <package id="Ghpr.MSTest" version="0.9.4" targetFramework="net452" />
   <package id="Ghpr.MSTestV2" version="0.9.4" targetFramework="net452" />
-  <package id="Ghpr.NUnit" version="0.9.4" targetFramework="net452" />
+  <package id="Ghpr.NUnit" version="0.9.4.1" targetFramework="net452" />
   <package id="MSTest.TestAdapter" version="1.4.0" targetFramework="net452" />
   <package id="MSTest.TestFramework" version="1.4.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net452" />


### PR DESCRIPTION
…tion mismatches

The build is still failing on Appveyor but not locally. While doing research, I came across some clues that point to the mismatched architecture as being a culprit. When you build the project locally, you see the following warning:`warning MSB3270: There was a mismatch between the processor architecture of the project being built`. Setting the processor architecture to x86 instead of AnyCPU made this warning go away so I'm hoping this will correct the build failure. If not, if you could create a branch that I can work off of, that would be great. 